### PR TITLE
feat(build): optional oam.js support -- binary target, typecheck, docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,10 @@ Thumbs.db
 bin/
 build-tmp/
 dist-release/
+
+# oam.js bytecode cache. Created in the working directory by any `oam run` /
+# `oam check` / `oam compile` invocation, so anyone who follows the optional
+# oam instructions in the README gets it whether or not they opted into
+# anything. Ignored rather than removed -- it is a cache and reusing it is the
+# point.
+oam/

--- a/README.md
+++ b/README.md
@@ -509,6 +509,31 @@ This shows a read-only banner in the Tailscale Admin Console pointing to your re
 - Node.js 20+ to run the server (22+ to develop — the test script passes a glob to `node --test`, supported from Node 21)
 - A Tailscale API key or OAuth client credentials
 
+## Running on oam.js (optional)
+
+[oam.js](https://oamjs.org) runs this server unmodified. Verified against oam 0.8.2: full MCP handshake, all 89 tools, all 4 resources, identical error messages, and a clean stdout protocol stream — from the shipped bundle *and* straight from the TypeScript source with no build step.
+
+```jsonc
+{
+  "mcpServers": {
+    "tailscale": {
+      "command": "oam",
+      "args": ["run", "/path/to/tailscale-mcp/dist/index.js"],
+      "env": { "TAILSCALE_API_KEY": "tskey-api-..." }
+    }
+  }
+}
+```
+
+**Node stays the default, deliberately.** An MCP client cold-starts this server once per session, so startup is the cost that actually gets paid, and on the machine this was measured on node won it — 437ms vs 1554ms for `oam run` over 10 warmed runs (an earlier 5-run round showed 326ms vs 427ms; the box was busy, so treat the magnitude as noisy and the direction as the finding). Preferring oam automatically would mean either a launcher that probes for it on every start — a cost paid by everyone, including the majority who do not have oam — or making oam a hard requirement. Neither is worth it to reach a runtime that is not faster here. Measure on your own hardware before concluding anything; if oam wins on yours, the config above is all you need.
+
+Two places oam *does* win for this repo, both opt-in and neither touching the npm package:
+
+- **`npm run check:oam`** — type-checks via `oam check` (tsgo, TypeScript 7 native). Measured 4015ms against 7680ms for `tsc --noEmit`, same clean result. `npx tsc --noEmit` remains the portable default.
+- **`npm run build:binary:oam`** — builds the standalone binary via `oam compile` instead of Node SEA. Measured ~57.7 MB against ~73.6 MB for the Node SEA carrier *before* its blob is injected. Writes to the same `bin/<platform>-<arch>/` path as `npm run build:binary`, so the release staging script consumes either unchanged — run one or the other. If you redistribute that binary it embeds oam's runtime, so ship oam's `LICENSE`, `NOTICE` and `THIRD_PARTY_LICENSES.md` with it.
+
+The source stays runtime-agnostic on purpose: no `oam:` imports anywhere, and tests stay on `node:test`. That is what keeps the Node fallback real rather than nominal. Note that any `oam` invocation writes a bytecode cache to `oam/` in the working directory — already in `.gitignore`.
+
 ## Contributing
 
 Contributions welcome. See [CONTRIBUTING.md](CONTRIBUTING.md) for the PR workflow and AI-agent guidelines. Please [open an issue](https://github.com/YawLabs/tailscale-mcp/issues) to discuss before a PR for anything beyond a typo fix.

--- a/package.json
+++ b/package.json
@@ -36,6 +36,9 @@
     "test:ci": "npm run test",
     "lint": "biome check src/",
     "lint:fix": "biome check --write src/",
+    "check:oam": "oam check src/index.ts",
+    "build:binary": "node scripts/build-binary.mjs",
+    "build:binary:oam": "node scripts/build-binary-oam.mjs",
     "prepublishOnly": "npm run clean && npm run build"
   },
   "overrides": {

--- a/scripts/build-binary-oam.mjs
+++ b/scripts/build-binary-oam.mjs
@@ -1,0 +1,107 @@
+#!/usr/bin/env node
+// Build a self-contained single-file binary using oam.js (`oam compile`).
+//
+// This is an ALTERNATIVE to scripts/build-binary.mjs (Node SEA), not a
+// replacement. Both write to the same bin/<platform>-<arch>/<cmd>[.exe] path so
+// scripts/stage-release-asset.mjs consumes either one unchanged -- run one or
+// the other, never both expecting both outputs to survive.
+//
+// Why offer it, measured on this repo rather than assumed:
+//   * oam compile output : ~57.7 MB, working, with bytecode embedded
+//   * Node SEA carrier   : ~73.6 MB BEFORE the blob is injected
+// so the oam binary is roughly 22% smaller for the same functionality. Node SEA
+// remains the default because it needs no toolchain beyond the Node already on
+// the build host; oam compile needs oam installed.
+//
+// What this does NOT change: the npm package. `dist/index.js` keeps its node
+// shebang and stays runtime-agnostic, because that is the channel ~every user
+// actually installs through. See the README's oam section for the cold-start
+// measurement behind that decision.
+//
+// Prerequisite: oam on PATH (https://oamjs.org). Override with OAM_BIN.
+
+import { execFileSync } from 'node:child_process';
+import { mkdirSync, readFileSync, rmSync, statSync } from 'node:fs';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import esbuild from 'esbuild';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const repoRoot = resolve(__dirname, '..');
+const isWin = process.platform === 'win32';
+
+const pkg = JSON.parse(readFileSync(join(repoRoot, 'package.json'), 'utf-8'));
+const { version } = pkg;
+// Derived from package.json so this stays copy-paste generic across @yawlabs/*
+// servers, matching build-binary.mjs.
+const binName = Object.keys(pkg.bin ?? {})[0] ?? pkg.name.split('/').pop();
+const binEntry = Object.values(pkg.bin ?? {})[0] ?? pkg.main ?? 'dist/index.js';
+const srcEntry = binEntry.replace(/^\.\//, '').replace(/^dist\//, 'src/').replace(/\.[cm]?js$/, '.ts');
+
+const platformDir = `${process.platform}-${process.arch}`;
+const binDir = join(repoRoot, 'bin', platformDir);
+const tmpDir = join(repoRoot, 'build-tmp');
+// .cjs extension is load-bearing -- see the CJS note on the bundle step below.
+const bundlePath = join(tmpDir, 'oam-bundle.cjs');
+const outExe = join(binDir, isWin ? `${binName}.exe` : binName);
+
+const oamBin = process.env.OAM_BIN || 'oam';
+
+function fmtSize(p) {
+  const bytes = statSync(p).size;
+  return `${(bytes / 1024 / 1024).toFixed(2)} MB (${bytes} bytes)`;
+}
+
+// Fail fast with an actionable message rather than a raw ENOENT spawn error.
+try {
+  const v = execFileSync(oamBin, ['--version'], { encoding: 'utf-8' }).trim();
+  console.log(`using ${v}`);
+} catch {
+  console.error(
+    `Could not run "${oamBin} --version".\n` +
+      `Install oam from https://oamjs.org, or set OAM_BIN to its absolute path.\n` +
+      `To build without oam, use the Node SEA path instead: node scripts/build-binary.mjs`,
+  );
+  process.exit(1);
+}
+
+mkdirSync(tmpDir, { recursive: true });
+mkdirSync(binDir, { recursive: true });
+
+// 1. Bundle to CJS. `oam compile` documents a "pre-bundled JS/CJS entry file",
+//    and an ESM bundle genuinely fails: compiling dist/index.js (ESM) produces a
+//    binary that dies at run time on `import { createRequire } from "node:module"`.
+//    It also only embeds bytecode for the CJS input -- the ESM attempt reported
+//    "no bytecode embedded". Same banner/define shape as build-binary.mjs so the
+//    two binaries are built from identical source semantics.
+await esbuild.build({
+  entryPoints: [join(repoRoot, srcEntry)],
+  bundle: true,
+  platform: 'node',
+  format: 'cjs',
+  target: 'node20',
+  banner: { js: "const __seaImportMetaUrl = require('node:url').pathToFileURL(__filename).href;" },
+  define: { __VERSION__: JSON.stringify(version), 'import.meta.url': '__seaImportMetaUrl' },
+  external: ['cpu-features'],
+  outfile: bundlePath,
+});
+console.log(`bundle: ${fmtSize(bundlePath)}`);
+
+// 2. Embed it. oam compile handles the carrier + bytecode itself, so there is no
+//    equivalent of the Node SEA copy/postject/codesign dance here.
+rmSync(outExe, { force: true });
+execFileSync(oamBin, ['compile', bundlePath, '--output', outExe], { stdio: 'inherit', cwd: repoRoot });
+
+console.log('');
+console.log(`OK  ${outExe}`);
+console.log(`    ${fmtSize(outExe)}`);
+console.log('');
+// oam compile prints this itself, but it is a redistribution obligation and is
+// easy to scroll past in CI logs -- restate it at the end where it is read.
+console.log('NOTE: this binary embeds oam\'s runtime (V8, ICU and others).');
+console.log('      If you redistribute it, ship oam\'s LICENSE, NOTICE and');
+console.log('      THIRD_PARTY_LICENSES.md alongside it.');
+console.log('');
+console.log('Verify with:');
+console.log(`    "${outExe}" --version`);
+console.log(`    "${outExe}" validate-acl <path-to-acl.json>`);


### PR DESCRIPTION
[oam.js](https://oamjs.org) runs this server unmodified. Verified against oam 0.8.2 by driving the real MCP protocol — not just `--version`: handshake, 89 tools, 4 resources, the no-credentials error path, a zod + `node:net` validation rejection, and stdout protocol purity. Identical results under node, under `oam run` on the bundle, under `oam run` on raw TypeScript with no build step, and under an oam-compiled binary.

## Node stays the default, deliberately

An MCP client cold-starts this server once per session, so startup is the cost actually paid — and node won it here:

| | node | oam |
|---|---|---|
| 10 warmed runs | **437ms** | 1554ms |
| earlier 5-run round | **326ms** | 427ms |

Direction consistent across both rounds; magnitude is noisy (loaded machine). Preferring oam automatically would need either a launcher probing for it on every start — a cost paid by everyone including the majority without oam — or a hard oam dependency. Neither is worth reaching a runtime that is not faster on this hardware. **Nothing on the npm path changes:** `dist/index.js` keeps its node shebang and stays runtime-agnostic.

## What oam does win (opt-in, off the npm path)

- **`npm run build:binary:oam`** — `oam compile` produces a working **57.7 MB** binary vs **73.6 MB** for the Node SEA carrier *before* its blob is injected. Writes to the same `bin/<platform>-<arch>/` path as the SEA builder, so `stage-release-asset.mjs` consumes either unchanged.
- **`npm run check:oam`** — `oam check` (tsgo, TypeScript 7 native): **4015ms** vs **7680ms** for `tsc --noEmit`, same clean result.
- **`npm run build:binary`** — names the existing Node SEA path, which had no script entry.

## Three things that only surfaced by running it

- **ESM `oam compile` produces a broken binary.** It built a 57 MB exe that died at run time on `import { createRequire } from "node:module"`, and reported "no bytecode embedded". Only the CJS bundle works and gets bytecode — the script bundles to CJS for that reason, documented inline.
- **oam writes an `oam/` bytecode cache into the working directory.** Anyone following the README would hit the same untracked noise; now gitignored.
- **Redistribution obligation.** An oam-compiled binary embeds oam's runtime (V8, ICU), so its `LICENSE`, `NOTICE` and `THIRD_PARTY_LICENSES.md` must ship alongside. oam prints this but it scrolls past in CI logs, so the script restates it at the end and the README carries it.

Source stays runtime-agnostic: no `oam:` imports, tests stay on `node:test`. That is what keeps the Node fallback real rather than nominal.

## Verification

tsc clean, biome clean, **1085/1085 tests pass**, tarball still 4 files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
