### PR TITLE
docs(release): correct the CI-history citation in the IS_CI comment

### DIFF
--- a/release.sh
+++ b/release.sh
@@ -107,11 +107,23 @@ fi
 
 # ---- Resolve version ----
 VERSION="${1:-}"
-# CI mode is dormant: all GitHub workflows were dropped in 1b18b85 (registry
-# publish folded into this script). The IS_CI branches are kept so a future
+# CI mode is dormant: this repo currently has no GitHub workflows at all
+# (.github/ holds only CODEOWNERS). The IS_CI branches are kept so a future
 # re-added tag workflow can reuse this script unchanged; until then every
 # release is a workstation release -- which also means no npm provenance
 # attestation (npm only attests from inside a supported CI environment).
+#
+# "Kept for a future re-added workflow" is not hypothetical -- it already
+# happened once, and the history is easy to misread:
+#   1f157c0  dropped the non-release workflows
+#   1b18b85  dropped release.yml, folding the registry publish into this script
+#   3754cf8  RE-ADDED release.yml for the scoop/homebrew binary pipeline
+#   14ef069  removed release.yml + dependabot.yml again  <- current state
+# An earlier version of this comment cited only 1b18b85, which was accurate
+# when written and stale from 3754cf8 onward. Both SHAs are real; cite 14ef069
+# for why there is no CI today. `git log --grep` finds only the most recent
+# removal and makes the older SHA look bogus -- use
+# `git log --diff-filter=D -- .github/workflows` instead.
 IS_CI="${CI:-false}"
 
 if [ -z "$VERSION" ]; then


### PR DESCRIPTION
The `IS_CI` comment cited `1b18b85` as when all workflows were dropped. Accurate when written, stale from `3754cf8` onward.

| commit | date | what |
|---|---|---|
| `1f157c0` | 2026-05-28 | dropped non-release workflows |
| `1b18b85` | 2026-05-28 | dropped `release.yml`, folded registry publish into `release.sh` |
| `3754cf8` | 2026-06-11 | **re-added** `release.yml` (scoop/homebrew binary pipeline) |
| `14ef069` | 2026-07-21 | removed `release.yml` + `dependabot.yml` again — current state |

The "no CI" claim is still true; the citation just no longer points at the commit responsible for it.

Worth the words because the stale citation actively misleads: `git log --grep "remove GitHub Actions"` surfaces only `14ef069`, making `1b18b85` look like a bogus or copy-pasted SHA when it is this repo's own commit. That exact wrong conclusion was reached in a session. The comment now names `--diff-filter=D -- .github/workflows` as the query that shows all of them.

Comment-only: `bash -n` clean, usage path unchanged, no executable lines touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)