### PR TITLE
feat(runtime): prefer oam, fall back to Node

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,7 +22,8 @@ Thumbs.db
 .playwright-mcp/
 
 # Single-binary (Node SEA) build pipeline outputs
-bin/
+bin/*
+!bin/tailscale-mcp.mjs
 build-tmp/
 dist-release/
 

--- a/bin/tailscale-mcp.mjs
+++ b/bin/tailscale-mcp.mjs
@@ -45,9 +45,32 @@ const exe = isWin ? "oam.exe" : "oam";
 
 /** Locate an oam binary, or null. Every branch is a stat, never a subprocess. */
 function findOam() {
+  // 1. Explicit override wins and is never second-guessed.
   const override = process.env.OAM_BIN;
   if (override) return existsSync(override) ? override : null;
 
+  // 2. Installed locations, BEFORE PATH. Someone who develops oam itself
+  //    usually has oam/target/release on PATH, and a build directory is the
+  //    wrong thing for a user-facing launcher to bind to: cargo replaces the
+  //    binary underneath running processes, and the dev build is not the
+  //    release the user installed. Preferring the installed copy makes the
+  //    default path "what a normal user has", and OAM_BIN remains the way to
+  //    point deliberately at a dev build.
+  //
+  //    Both forms are checked on Windows: the installer defaults to
+  //    %LOCALAPPDATA%oamin there, but oam's docs name ~/.oam/bin first and
+  //    OAM_INSTALL_DIR can pick either, so checking one silently misses a real
+  //    install.
+  const installed = [join(homedir(), ".oam", "bin", exe)];
+  if (isWin) {
+    installed.unshift(join(process.env.LOCALAPPDATA ?? join(homedir(), "AppData", "Local"), "oam", "bin", exe));
+  }
+  for (const candidate of installed) {
+    if (existsSync(candidate)) return candidate;
+  }
+
+  // 3. PATH, resolved manually rather than by spawning `which`/`where`, which
+  //    would cost a subprocess on every launch just to decide whether to spawn.
   const pathExt = isWin ? (process.env.PATHEXT ?? ".EXE").split(";").filter(Boolean) : [""];
   for (const dir of (process.env.PATH ?? "").split(delimiter)) {
     if (!dir) continue;
@@ -55,15 +78,6 @@ function findOam() {
       const candidate = join(dir, isWin ? `oam${ext.toLowerCase()}` : "oam");
       if (existsSync(candidate)) return candidate;
     }
-  }
-
-  // The per-user locations oamjs.org's installers write to. Checked because an
-  // MCP host launched from a GUI often has a PATH that omits them.
-  const installed = isWin
-    ? [join(process.env.LOCALAPPDATA ?? join(homedir(), "AppData", "Local"), "oam", "bin", exe)]
-    : [join(homedir(), ".oam", "bin", exe)];
-  for (const candidate of installed) {
-    if (existsSync(candidate)) return candidate;
   }
 
   return null;

--- a/bin/tailscale-mcp.mjs
+++ b/bin/tailscale-mcp.mjs
@@ -1,0 +1,155 @@
+#!/usr/bin/env node
+/**
+ * Runtime launcher for @yawlabs/tailscale-mcp.
+ *
+ * Prefers the oam runtime (https://oamjs.org) and falls back to the Node
+ * process already running this file.
+ *
+ *
+ * WHY THE FALLBACK COSTS NOTHING
+ * npm has already started Node to run this launcher, so falling back is a
+ * plain `import()` of the server into THIS process: no extra spawn, no extra
+ * startup, byte-identical to invoking dist/index.js directly. Discovery is
+ * stat-only -- never a subprocess -- so the miss case stays sub-millisecond.
+ *
+ * WHAT THE OAM PATH COSTS
+ * Reaching oam through an npm `bin` means Node boots first and oam boots
+ * second, so the launcher is slower than either runtime alone. Measured on
+ * npmjs-mcp (windows-arm64, n=12 medians, spawn to first MCP initialize):
+ * oam 116ms, node 172ms, launcher 243ms. oam is the fastest runtime and the
+ * launcher is the slowest path -- it exists for `npx` convenience.
+ *
+ * For an MCP host config, point straight at oam and skip this file:
+ *   { "command": "oam", "args": ["run", "<abs>/dist/index.js"] }
+ *
+ * SELECTION
+ *   TAILSCALE_MCP_RUNTIME=oam    require oam; fail loudly if it is missing
+ *   TAILSCALE_MCP_RUNTIME=node   never use oam
+ *   TAILSCALE_MCP_RUNTIME=auto   prefer oam, silently fall back (default)
+ *   OAM_BIN=/path/to/oam     explicit binary, checked before any discovery
+ */
+
+import { spawn } from "node:child_process";
+import { existsSync } from "node:fs";
+import { constants, homedir } from "node:os";
+import { delimiter, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+// Two forms, deliberately. `import()` on Windows REJECTS a bare `C:\...` path
+// with ERR_UNSUPPORTED_ESM_URL_SCHEME (it reads `c:` as a protocol), so the
+// in-process fallback must use the file:// URL. spawn() needs a real path.
+const SERVER_URL = new URL("../dist/index.js", import.meta.url);
+const SERVER_ENTRY = fileURLToPath(SERVER_URL);
+const isWin = process.platform === "win32";
+const exe = isWin ? "oam.exe" : "oam";
+
+/** Locate an oam binary, or null. Every branch is a stat, never a subprocess. */
+function findOam() {
+  const override = process.env.OAM_BIN;
+  if (override) return existsSync(override) ? override : null;
+
+  const pathExt = isWin ? (process.env.PATHEXT ?? ".EXE").split(";").filter(Boolean) : [""];
+  for (const dir of (process.env.PATH ?? "").split(delimiter)) {
+    if (!dir) continue;
+    for (const ext of isWin ? pathExt : [""]) {
+      const candidate = join(dir, isWin ? `oam${ext.toLowerCase()}` : "oam");
+      if (existsSync(candidate)) return candidate;
+    }
+  }
+
+  // The per-user locations oamjs.org's installers write to. Checked because an
+  // MCP host launched from a GUI often has a PATH that omits them.
+  const installed = isWin
+    ? [join(process.env.LOCALAPPDATA ?? join(homedir(), "AppData", "Local"), "oam", "bin", exe)]
+    : [join(homedir(), ".oam", "bin", exe)];
+  for (const candidate of installed) {
+    if (existsSync(candidate)) return candidate;
+  }
+
+  return null;
+}
+
+/** Run the server in THIS process. The zero-overhead fallback. */
+async function runInProcess() {
+  // A server may gate its bootstrap on being the process ENTRY POINT --
+  // `import.meta.url === pathToFileURL(process.argv[1]).href` -- so that its own
+  // test file can import the module for unit tests without connecting a stdio
+  // transport. aws-mcp does exactly this. Importing the server here would leave
+  // argv[1] pointing at THIS launcher, the guard would read false, and the
+  // server would load but never serve: the MCP handshake just hangs.
+  //
+  // Point argv[1] at the server first, so the in-process path is
+  // indistinguishable from having executed the file directly. The spawn path
+  // needs no equivalent -- there argv[1] is already the server.
+  process.argv[1] = SERVER_ENTRY;
+  await import(SERVER_URL.href);
+}
+
+const mode = (process.env.TAILSCALE_MCP_RUNTIME ?? "auto").toLowerCase();
+
+if (mode === "node") {
+  await runInProcess();
+} else {
+  const oam = findOam();
+
+  if (!oam) {
+    if (mode === "oam") {
+      // Explicitly demanded, so this is a real misconfiguration. writeSync
+      // because stderr is async for TTYs/pipes on Windows and process.exit
+      // truncates pending writes.
+      const { writeSync } = await import("node:fs");
+      writeSync(
+        2,
+        "tailscale-mcp: TAILSCALE_MCP_RUNTIME=oam but no oam binary was found.\n" +
+          "Install from https://oamjs.org, set OAM_BIN=/path/to/oam, or use TAILSCALE_MCP_RUNTIME=node.\n",
+      );
+      process.exit(1);
+    }
+    await runInProcess();
+  } else {
+    // `--` separates oam's own flags from the script's argv, so `tailscale-mcp
+    // --version` and any host-supplied flags survive the hop unchanged.
+    const child = spawn(oam, ["run", SERVER_ENTRY, "--", ...process.argv.slice(2)], {
+      // inherit keeps the SAME fds, so MCP's newline-delimited JSON framing on
+      // stdin/stdout is untouched and the host's stdin-close still reaches the
+      // server's shutdown path.
+      stdio: "inherit",
+      env: process.env,
+      windowsHide: true,
+    });
+
+    // If oam cannot be executed at all (deleted between the stat and the spawn,
+    // wrong arch, permission), fall back rather than failing the whole server.
+    // `spawned` prevents falling back AFTER the child started, which would
+    // double-start the server on the same stdio.
+    let spawned = false;
+    child.on("spawn", () => {
+      spawned = true;
+    });
+    child.on("error", (err) => {
+      if (spawned) return;
+      if (mode === "oam") {
+        process.stderr.write(`tailscale-mcp: failed to launch oam (${err.message})\n`);
+        process.exit(1);
+      }
+      void runInProcess();
+    });
+
+    // Forward termination so the server's own shutdown path runs in the child
+    // rather than the child being orphaned. No-op on Windows, harmless to add.
+    for (const sig of ["SIGINT", "SIGTERM"]) {
+      process.on(sig, () => {
+        if (!child.killed) child.kill(sig);
+      });
+    }
+
+    child.on("exit", (code, signal) => {
+      // Mirror the child's fate: a signal death becomes 128+n so callers see a
+      // conventional shell exit status rather than a bare 0.
+      if (signal) {
+        process.exit(128 + (constants.signals[signal] ?? 15));
+      }
+      process.exit(code ?? 0);
+    });
+  }
+}

--- a/package.json
+++ b/package.json
@@ -20,9 +20,10 @@
   "type": "module",
   "main": "dist/index.js",
   "bin": {
-    "tailscale-mcp": "dist/index.js"
+    "tailscale-mcp": "bin/tailscale-mcp.mjs"
   },
   "files": [
+    "bin/tailscale-mcp.mjs",
     "dist/index.js",
     "LICENSE",
     "README.md"

--- a/scripts/build-binary.mjs
+++ b/scripts/build-binary.mjs
@@ -23,7 +23,7 @@
 // package-lock.json, src/, or node_modules, and it never runs `npm install`.
 
 import { execFileSync } from 'node:child_process';
-import { chmodSync, copyFileSync, mkdirSync, readFileSync, rmSync, statSync } from 'node:fs';
+import { existsSync, chmodSync, copyFileSync, mkdirSync, readFileSync, rmSync, statSync } from 'node:fs';
 import { dirname, join, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import esbuild from 'esbuild';
@@ -40,8 +40,17 @@ const { version } = pkg;
 const binName = Object.keys(pkg.bin ?? {})[0] ?? pkg.name.split('/').pop();
 // Bundle the SOURCE behind the bin's dist entry (src/index.ts, src/server.ts,
 // src/runner.ts, ...) so this works regardless of the server's entry filename.
-const binEntry = Object.values(pkg.bin ?? {})[0] ?? pkg.main ?? 'dist/index.js';
-const srcEntry = binEntry.replace(/^\.\//, '').replace(/^dist\//, 'src/').replace(/\.[cm]?js$/, '.ts');
+// Pinned, NOT derived from `bin`. Mapping bin's VALUE to a source path
+// (dist/index.js -> src/index.ts) breaks the moment `bin` is repointed at the
+// runtime launcher: it yields bin/tailscale-mcp.ts, which does not exist.
+// postgres-mcp shipped exactly that breakage in its 0.9.0. This script is a
+// manual per-host step that neither `npm test` nor the release flow runs, so a
+// wrong guess stays invisible until someone builds a binary.
+const srcEntry = 'src/index.ts';
+if (!existsSync(join(repoRoot, srcEntry))) {
+  console.error(`build-binary: source entry '${srcEntry}' does not exist -- update this constant`);
+  process.exit(1);
+}
 
 const platformDir = `${process.platform}-${process.arch}`;
 const binDir = join(repoRoot, 'bin', platformDir);


### PR DESCRIPTION
Ports the launcher pattern from npmjs-mcp / postgres-mcp / caddy-mcp.

`bin/tailscale-mcp.mjs` prefers [oam](https://oamjs.org) and falls back to Node. `TAILSCALE_MCP_RUNTIME` = `auto`/`oam`/`node`; `OAM_BIN` overrides discovery. The fallback is an in-process `import()` — npm already started Node to run the launcher — so users without oam pay nothing.

**Verified against the MCP surface on both runtimes** (initialize + tools/list, identical counts), not just `--version`.

### Two latent traps closed

Both already shipped as real bugs in sibling repos:

- **`.gitignore` excluded `bin/`.** A negation cannot re-include a file under an excluded *directory*, so the launcher would have been untracked and absent from every fresh clone — exactly what postgres-mcp shipped. Now `bin/*` plus a negation; platform output stays ignored, verified both directions.
- **`build-binary.mjs` derived the CLI entry from `bin`'s value**, so moving `bin` to the launcher would have made it hunt for `bin/tailscale-mcp.ts` — the breakage postgres-mcp shipped in 0.9.0. Pinned, with an existence check.

### One bug caught by testing properly

The in-process fallback now sets `process.argv[1]` to the server before importing. A server may gate its bootstrap on being the process entry point so its own tests can import the module without opening a transport — **aws-mcp does exactly that**, and without this the handshake loaded the module and then hung forever. `--version` passed the whole time; only the MCP surface exposed it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)